### PR TITLE
Add StaticSymbols filter to fulfill the need of StaticAssets

### DIFF
--- a/pipeline_live/data/polygon/filters.py
+++ b/pipeline_live/data/polygon/filters.py
@@ -21,3 +21,12 @@ class IsPrimaryShareEmulation(CustomFilter):
             for symbol in symbols
         ], dtype=bool)
         out[:] = ary
+
+class StaticSymbols(CustomFilter):
+    inputs = ()
+    window_length = 1
+    params = ('symbols',)
+
+    def compute(self, today, assets, out, symbols, *inputs):
+        ary = np.array([symbol in symbols for symbol in assets])
+        out[:] = ary

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from pipeline_live.data.polygon.fundamentals import PolygonCompany
-from pipeline_live.data.polygon.filters import IsPrimaryShareEmulation
+from pipeline_live.data.polygon.filters import IsPrimaryShareEmulation, StaticSymbols
 
 from .datamock import mock_tradeapi
 
@@ -28,3 +28,12 @@ def test_IsPrimaryShareEmulation(tradeapi, data_path):
     out = [None, None]
     emu.compute(today, symbols, out)
     assert not out[0]
+
+def test_StaticSymbols(tradeapi, data_path):
+    emu = StaticSymbols(symbols=('A', 'BB'))
+
+    today = object()
+    assets = ['A', 'AA', 'BB']
+    out = [None, None, None]
+    emu.compute(today, assets, out)
+    assert not out[1]


### PR DESCRIPTION
StatisAssets from zipline does not seem to work in pylivetrader, this adds a StaticSymbols filter that functions very similarly, but operates off the symbols rather than basing off of sids.