### PR TITLE
IEX Cloud & Alpaca Pricing

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 alpaca-trade-api = "*"
-iexfinance = "==0.4.0"
+iexfinance = ">=0.4.1"
 zipline = "==1.3.0"
 numpy = "==1.16.1"
 

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-alpaca-trade-api = "*"
+alpaca-trade-api = ">=0.29"
 iexfinance = ">=0.4.1"
 zipline = "==1.3.0"
 numpy = "==1.16.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8b5ef75a6eeed4514ef3be7aa8f1b1a6f08b1d41a38c9c5b5c1ff47655896386"
+            "sha256": "20e3015f4f3fcead9b55726d4691e57d8010d55725abbfdb71d9737cc4097dec"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,23 +18,23 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:16505782b229007ae905ef9e0ae6e880fddafa406f086ac7d442c1aaf712f8c2"
+                "sha256:828dcaa922155a2b7166c4f36ec45268944e4055c86499bd14319b4c8c0094b7"
             ],
-            "version": "==1.0.7"
+            "version": "==1.0.10"
         },
         "alpaca-trade-api": {
             "hashes": [
-                "sha256:3156a5760ac463987eff0a96bfd680336ef776e03f6abab60a9837771fa8f118",
-                "sha256:7fa464dab8889fb13b3779475a1d0325b9cf9e6203c019a2ff5bbc7ec4b150d4"
+                "sha256:8b6ca679e00bf99eea9891c241df6093cab3181db6cbad04df9902c4e1e341d7",
+                "sha256:947e362eae1b0d25e5a3b3fe54dcef3ca5ee8e4ccd9895d51828620bc0b23058"
             ],
             "index": "pypi",
-            "version": "==0.25"
+            "version": "==0.29"
         },
         "asyncio-nats-client": {
             "hashes": [
-                "sha256:12ac47284b20bd0359ee9579972892c8d8a08d23c2bbcf6f637b6f2feff3aa4d"
+                "sha256:c36e464a33e2d1bb59437b68ad74051f9f3113969108e4f8008b1e3fb5a2969f"
             ],
-            "version": "==0.8.2"
+            "version": "==0.9.2"
         },
         "bcolz": {
             "hashes": [
@@ -50,10 +50,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.6.16"
         },
         "chardet": {
             "hashes": [
@@ -84,43 +84,43 @@
         },
         "cython": {
             "hashes": [
-                "sha256:0154d3eead9432dfbef489fecf3a9d9202da0ab4966b796c319c4a3048ff2c03",
-                "sha256:0355e23994919a6abfce3b9493062f69317f2057560bde694493fa18306b7824",
-                "sha256:06c0c1332ce36bb6feb6c3590cd72c0b4fa59b34202b1975d484319595e2a548",
-                "sha256:0970fc905136b520a7595e1d43ff465a8ab24103ac54da801f9bb25be940bb5b",
-                "sha256:1242351548eeb2c99ca2958fa2eebae08fc361f30d56588ff4f28cdb63a440c1",
-                "sha256:17a573b551aa34878eba7e0b34a774b18e4b2b35943b2e7d2ae0a31ac5446e39",
-                "sha256:28025cd1d36df61257646d97325046ee894118e267a49d19fd321fbca413c3df",
-                "sha256:37d1d560d49985b87629785cf9971add6dd621fc9db1505a5811dcb0feb34a94",
-                "sha256:3f6ed611cf01e7bbd852bb4f77bea05f0fcca0556926aa0de21a20f719c4abc5",
-                "sha256:5254de3aecc883d89243f37da74ceff70d9bf459b94ad816f889c794a51a3e76",
-                "sha256:54484d6b3c102c1e52ebb5dbcee4b7b42efae96ac3d1a2e1d640acab8d7c6fbe",
-                "sha256:6760738fab5d44e3615fb4c3a12dd5b766850e79dc1bd2ecb4c1df361871f1c3",
-                "sha256:69c3cd2fe8c2db18a2042aaeb8b3bb0a9ea214c1612c8431fab0acb5ed434b07",
-                "sha256:73d3e28f9fb445bf67cc753c826e63ce9c3308d62d7e642dfb8cc3556f3ac685",
-                "sha256:74763f2ac133aabb1a8260ff00303571b91b7c866e0bbcd05159dc72a67f9911",
-                "sha256:764049a11173b2039674879b1be0d73e2288af4fc1ad8177aa99cdc0de335b31",
-                "sha256:9d5290d749099a8e446422adfb0aa2142c711284800fb1eb70f595101e32cbf1",
-                "sha256:a12a83d72aa1298236b63c1d5e95de6230c634cc9c3eb06be51c67f88ccedd92",
-                "sha256:aa83ce29f04c3d83d51863819281be8bf35d22ae1b8fba9a32cd8a84cd471998",
-                "sha256:ab3d291304c4e4160276533d3e4e36380ba18dacf2c8d6573980f2ef168f3afb",
-                "sha256:b1b4ffcb39e77e29862e23d3a25a7c307cac85c8d0654d51547059c053060fc5",
-                "sha256:c0ef97e126831ec8ae616c5a4d9b321b6e792cf48a1bf473fd6555226c91839f",
-                "sha256:c15c3fe45855d985922c0f74f8c282b126b3458d5662c4875ae0d088d12b7c3f",
-                "sha256:cdafe6f7f7dd32ce79b9d5dade7045de7c89d747bce4804f41be84027dc23312",
-                "sha256:d4d9a9531d3f5990f2f043288359c83527ab927ef4ad9c55a831166d68a53baa",
-                "sha256:f5722b4eb8052405c314dfae8a1a6e27ee493d051354c53f1ceb8f4e1fd3f075",
-                "sha256:f581171b9c3b4d5048ce64634b210bfccec06ef3a7422f1807a2a8de31a3c075",
-                "sha256:f8971da715deda1670e2383185c0c2a1ea819fb17221953f4d0c20d0f14ef24d"
+                "sha256:0afa0b121b89de619e71587e25702e2b7068d7da2164c47e6eee80c17823a62f",
+                "sha256:1c608ba76f7a20cc9f0c021b7fe5cb04bc1a70327ae93a9298b1bc3e0edddebe",
+                "sha256:26229570d6787ff3caa932fe9d802960f51a89239b990d275ae845405ce43857",
+                "sha256:2a9deafa437b6154cac2f25bb88e0bfd075a897c8dc847669d6f478d7e3ee6b1",
+                "sha256:2f28396fbce6d9d68a40edbf49a6729cf9d92a4d39ff0f501947a89188e9099f",
+                "sha256:3983dd7b67297db299b403b29b328d9e03e14c4c590ea90aa1ad1d7b35fb178b",
+                "sha256:4100a3f8e8bbe47d499cdac00e56d5fe750f739701ea52dc049b6c56f5421d97",
+                "sha256:51abfaa7b6c66f3f18028876713c8804e73d4c2b6ceddbcbcfa8ec62429377f0",
+                "sha256:61c24f4554efdb8fb1ac6c8e75dab301bcdf2b7b739ed0c2b267493bb43163c5",
+                "sha256:700ccf921b2fdc9b23910e95b5caae4b35767685e0812343fa7172409f1b5830",
+                "sha256:7b41eb2e792822a790cb2a171df49d1a9e0baaa8e81f58077b7380a273b93d5f",
+                "sha256:803987d3b16d55faa997bfc12e8b97f1091f145930dee229b020487aed8a1f44",
+                "sha256:99af5cfcd208c81998dcf44b3ca466dee7e17453cfb50e98b87947c3a86f8753",
+                "sha256:9faea1cca34501c7e139bc7ef8e504d532b77865c58592493e2c154a003b450f",
+                "sha256:a7ba4c9a174db841cfee9a0b92563862a0301d7ca543334666c7266b541f141a",
+                "sha256:b26071c2313d1880599c69fd831a07b32a8c961ba69d7ccbe5db1cd8d319a4ca",
+                "sha256:b49dc8e1116abde13a3e6a9eb8da6ab292c5a3325155fb872e39011b110b37e6",
+                "sha256:bd40def0fd013569887008baa6da9ca428e3d7247adeeaeada153006227bb2e7",
+                "sha256:bfd0db770e8bd4e044e20298dcae6dfc42561f85d17ee546dcd978c8b23066ae",
+                "sha256:c2fad1efae5889925c8fd7867fdd61f59480e4e0b510f9db096c912e884704f1",
+                "sha256:c81aea93d526ccf6bc0b842c91216ee9867cd8792f6725a00f19c8b5837e1715",
+                "sha256:da786e039b4ad2bce3d53d4799438cf1f5e01a0108f1b8d78ac08e6627281b1a",
+                "sha256:deab85a069397540987082d251e9c89e0e5b2e3e044014344ff81f60e211fc4b",
+                "sha256:e3f1e6224c3407beb1849bdc5ae3150929e593e4cffff6ca41c6ec2b10942c80",
+                "sha256:e74eb224e53aae3943d66e2d29fe42322d5753fd4c0641329bccb7efb3a46552",
+                "sha256:ee697c7ea65cb14915a64f36874da8ffc2123df43cf8bc952172e04a26656cd6",
+                "sha256:f37792b16d11606c28e428460bd6a3d14b8917b109e77cdbe4ca78b0b9a52c87",
+                "sha256:fd2906b54cbf879c09d875ad4e4687c58d87f5ed03496063fec1c9065569fd5d"
             ],
-            "version": "==0.29.5"
+            "version": "==0.29.10"
         },
         "decorator": {
             "hashes": [
-                "sha256:33cd704aea07b4c28b3eb2c97d288a06918275dac0ecebdaf1bc8a48d98adb9e",
-                "sha256:cabb249f4710888a2fc0e13e9a16c343d932033718ff62e1e9bc93a9d3a9122b"
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
             ],
-            "version": "==4.3.2"
+            "version": "==4.4.0"
         },
         "empyrical": {
             "hashes": [
@@ -137,11 +137,11 @@
         },
         "iexfinance": {
             "hashes": [
-                "sha256:e81696eb09440b13f13a86cc9a8c51b2cc7a23b14a940d15933b5e09750a0caf",
-                "sha256:ed91710b8fe5e2dccd00b0c766e094838c1094c53b53b5ff230c78a771c2a278"
+                "sha256:a086bd46f14340373328824cb2cf9a75f3db101b0869e6a99d9b110e38272d61",
+                "sha256:e74c9e3ff7ebe2b94a8588b04b93573f50d3336f418e352c9437fe92818a3005"
             ],
             "index": "pypi",
-            "version": "==0.4.0"
+            "version": "==0.4.1"
         },
         "intervaltree": {
             "hashes": [
@@ -163,40 +163,38 @@
         },
         "lxml": {
             "hashes": [
-                "sha256:0537eee4902e8bf4f41bfee8133f7edf96533dd175930a12086d6a40d62376b2",
-                "sha256:0562ec748abd230ab87d73384e08fa784f9b9cee89e28696087d2d22c052cc27",
-                "sha256:09e91831e749fbf0f24608694e4573be0ef51430229450c39c83176cc2e2d353",
-                "sha256:1ae4c0722fc70c0d4fba43ae33c2885f705e96dce1db41f75ae14a2d2749b428",
-                "sha256:1c630c083d782cbaf1f7f37f6cac87bda9cff643cf2803a5f180f30d97955cef",
-                "sha256:2fe74e3836bd8c0fa7467ffae05545233c7f37de1eb765cacfda15ad20c6574a",
-                "sha256:37af783c2667ead34a811037bda56a0b142ac8438f7ed29ae93f82ddb812fbd6",
-                "sha256:3f2d9eafbb0b24a33f56acd16f39fc935756524dcb3172892721c54713964c70",
-                "sha256:47d8365a8ef14097aa4c65730689be51851b4ade677285a3b2daa03b37893e26",
-                "sha256:510e904079bc56ea784677348e151e1156040dbfb736f1d8ea4b9e6d0ab2d9f4",
-                "sha256:58d0851da422bba31c7f652a7e9335313cf94a641aa6d73b8f3c67602f75b593",
-                "sha256:7940d5c2185ffb989203dacbb28e6ae88b4f1bb25d04e17f94b0edd82232bcbd",
-                "sha256:7cf39bb3a905579836f7a8f3a45320d9eb22f16ab0c1e112efb940ced4d057a5",
-                "sha256:9563a23c1456c0ab550c087833bc13fcc61013a66c6420921d5b70550ea312bf",
-                "sha256:95b392952935947e0786a90b75cc33388549dcb19af716b525dae65b186138fc",
-                "sha256:983129f3fd3cef5c3cf067adcca56e30a169656c00fcc6c648629dbb850b27fa",
-                "sha256:a0b75b1f1854771844c647c464533def3e0a899dd094a85d1d4ed72ecaaee93d",
-                "sha256:b5db89cc0ef624f3a81214b7961a99f443b8c91e88188376b6b322fd10d5b118",
-                "sha256:c0a7751ba1a4bfbe7831920d98cee3ce748007eab8dfda74593d44079568219a",
-                "sha256:c0c5a7d4aafcc30c9b6d8613a362567e32e5f5b708dc41bc3a81dac56f8af8bb",
-                "sha256:d4d63d85eacc6cb37b459b16061e1f100d154bee89dc8d8f9a6128a5a538e92e",
-                "sha256:da5e7e941d6e71c9c9a717c93725cda0708c2474f532e3680ac5e39ec57d224d",
-                "sha256:dccad2b3c583f036f43f80ac99ee212c2fa9a45151358d55f13004d095e683b2",
-                "sha256:df46307d39f2aeaafa1d25309b8a8d11738b73e9861f72d4d0a092528f498baa",
-                "sha256:e70b5e1cb48828ddd2818f99b1662cb9226dc6f57d07fc75485405c77da17436",
-                "sha256:ea825562b8cd057cbc9810d496b8b5dec37a1e2fc7b27bc7c1e72ce94462a09a"
+                "sha256:06c7616601430aa140a69f97e3116308fffe0848f543b639a5ec2e8920ae72fd",
+                "sha256:177202792f9842374a8077735c69c41a4282183f7851443d2beb8ee310720819",
+                "sha256:19317ad721ceb9e39847d11131903931e2794e447d4751ebb0d9236f1b349ff2",
+                "sha256:36d206e62f3e5dbaafd4ec692b67157e271f5da7fd925fda8515da675eace50d",
+                "sha256:387115b066c797c85f9861a9613abf50046a15aac16759bc92d04f94acfad082",
+                "sha256:3ce1c49d4b4a7bc75fb12acb3a6247bb7a91fe420542e6d671ba9187d12a12c2",
+                "sha256:4d2a5a7d6b0dbb8c37dab66a8ce09a8761409c044017721c21718659fa3365a1",
+                "sha256:58d0a1b33364d1253a88d18df6c0b2676a1746d27c969dc9e32d143a3701dda5",
+                "sha256:62a651c618b846b88fdcae0533ec23f185bb322d6c1845733f3123e8980c1d1b",
+                "sha256:69ff21064e7debc9b1b1e2eee8c2d686d042d4257186d70b338206a80c5bc5ea",
+                "sha256:7060453eba9ba59d821625c6af6a266bd68277dce6577f754d1eb9116c094266",
+                "sha256:7d26b36a9c4bce53b9cfe42e67849ae3c5c23558bc08363e53ffd6d94f4ff4d2",
+                "sha256:83b427ad2bfa0b9705e02a83d8d607d2c2f01889eb138168e462a3a052c42368",
+                "sha256:923d03c84534078386cf50193057aae98fa94cace8ea7580b74754493fda73ad",
+                "sha256:b773715609649a1a180025213f67ffdeb5a4878c784293ada300ee95a1f3257b",
+                "sha256:baff149c174e9108d4a2fee192c496711be85534eab63adb122f93e70aa35431",
+                "sha256:bca9d118b1014b4c2d19319b10a3ebed508ff649396ce1855e1c96528d9b2fa9",
+                "sha256:ce580c28845581535dc6000fc7c35fdadf8bea7ccb57d6321b044508e9ba0685",
+                "sha256:d34923a569e70224d88e6682490e24c842907ba2c948c5fd26185413cbe0cd96",
+                "sha256:dd9f0e531a049d8b35ec5e6c68a37f1ba6ec3a591415e6804cbdf652793d15d7",
+                "sha256:ecb805cbfe9102f3fd3d2ef16dfe5ae9e2d7a7dfbba92f4ff1e16ac9784dbfb0",
+                "sha256:ede9aad2197a0202caff35d417b671f5f91a3631477441076082a17c94edd846",
+                "sha256:ef2d1fc370400e0aa755aab0b20cf4f1d0e934e7fd5244f3dd4869078e4942b9",
+                "sha256:f2fec194a49bfaef42a548ee657362af5c7a640da757f6f452a35da7dd9f923c"
             ],
-            "version": "==4.3.1"
+            "version": "==4.3.4"
         },
         "mako": {
             "hashes": [
-                "sha256:4e02fde57bd4abb5ec400181e4c314f56ac3e49ba4fb8b0d50bba18cb27d25ae"
+                "sha256:0cfa65de3a835e87eeca6ac856b3013aade55f49e32515f65d999f91a2324162"
             ],
-            "version": "==1.0.7"
+            "version": "==1.0.12"
         },
         "markupsafe": {
             "hashes": [
@@ -230,6 +228,13 @@
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
             "version": "==1.1.1"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3",
+                "sha256:d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8"
+            ],
+            "version": "==3.0.5"
         },
         "multipledispatch": {
             "hashes": [
@@ -360,17 +365,17 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
+                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
             ],
-            "version": "==2018.9"
+            "version": "==2019.1"
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
-            "version": "==2.21.0"
+            "version": "==2.22.0"
         },
         "requests-file": {
             "hashes": [
@@ -381,36 +386,24 @@
         },
         "scipy": {
             "hashes": [
-                "sha256:014cb900c003b5ac81a53f2403294e8ecf37aedc315b59a6b9370dce0aa7627a",
-                "sha256:281a34da34a5e0de42d26aed692ab710141cad9d5d218b20643a9cb538ace976",
-                "sha256:588f9cc4bfab04c45fbd19c1354b5ade377a8124d6151d511c83730a9b6b2338",
-                "sha256:5a10661accd36b6e2e8855addcf3d675d6222006a15795420a39c040362def66",
-                "sha256:628f60be272512ca1123524969649a8cb5ae8b31cca349f7c6f8903daf9034d7",
-                "sha256:6dcc43a88e25b815c2dea1c6fac7339779fc988f5df8396e1de01610604a7c38",
-                "sha256:70e37cec0ac0fe95c85b74ca4e0620169590fd5d3f44765f3c3a532cedb0e5fd",
-                "sha256:7274735fb6fb5d67d3789ddec2cd53ed6362539b41aa6cc0d33a06c003aaa390",
-                "sha256:78e12972e144da47326958ac40c2bd1c1cca908edc8b01c26a36f9ffd3dce466",
-                "sha256:790cbd3c8d09f3a6d9c47c4558841e25bac34eb7a0864a9def8f26be0b8706af",
-                "sha256:79792c8fe8e9d06ebc50fe23266522c8c89f20aa94ac8e80472917ecdce1e5ba",
-                "sha256:865afedf35aaef6df6344bee0de391ee5e99d6e802950a237f9fb9b13e441f91",
-                "sha256:870fd401ec7b64a895cff8e206ee16569158db00254b2f7157b4c9a5db72c722",
-                "sha256:963815c226b29b0176d5e3d37fc9de46e2778ce4636a5a7af11a48122ef2577c",
-                "sha256:9726791484f08e394af0b59eb80489ad94d0a53bbb58ab1837dcad4d58489863",
-                "sha256:9de84a71bb7979aa8c089c4fb0ea0e2ed3917df3fb2a287a41aaea54bbad7f5d",
-                "sha256:b2c324ddc5d6dbd3f13680ad16a29425841876a84a1de23a984236d1afff4fa6",
-                "sha256:b86ae13c597fca087cb8c193870507c8916cefb21e52e1897da320b5a35075e5",
-                "sha256:ba0488d4dbba2af5bf9596b849873102d612e49a118c512d9d302ceafa36e01a",
-                "sha256:d78702af4102a3a4e23bb7372cec283e78f32f5573d92091aa6aaba870370fe1",
-                "sha256:def0e5d681dd3eb562b059d355ae8bebe27f5cc455ab7c2b6655586b63d3a8ea",
-                "sha256:e085d1babcb419bbe58e2e805ac61924dac4ca45a07c9fa081144739e500aa3c",
-                "sha256:e2cfcbab37c082a5087aba5ff00209999053260441caadd4f0e8f4c2d6b72088",
-                "sha256:e742f1f5dcaf222e8471c37ee3d1fd561568a16bb52e031c25674ff1cf9702d5",
-                "sha256:f06819b028b8ef9010281e74c59cb35483933583043091ed6b261bb1540f11cc",
-                "sha256:f15f2d60a11c306de7700ee9f65df7e9e463848dbea9c8051e293b704038da60",
-                "sha256:f31338ee269d201abe76083a990905473987371ff6f3fdb76a3f9073a361cf37",
-                "sha256:f6b88c8d302c3dac8dff7766955e38d670c82e0d79edfc7eae47d6bb2c186594"
+                "sha256:03b1e0775edbe6a4c64effb05fff2ce1429b76d29d754aa5ee2d848b60033351",
+                "sha256:09d008237baabf52a5d4f5a6fcf9b3c03408f3f61a69c404472a16861a73917e",
+                "sha256:10325f0ffac2400b1ec09537b7e403419dcd25d9fee602a44e8a32119af9079e",
+                "sha256:1db9f964ed9c52dc5bd6127f0dd90ac89791daa690a5665cc01eae185912e1ba",
+                "sha256:409846be9d6bdcbd78b9e5afe2f64b2da5a923dd7c1cd0615ce589489533fdbb",
+                "sha256:4907040f62b91c2e170359c3d36c000af783f0fa1516a83d6c1517cde0af5340",
+                "sha256:6c0543f2fdd38dee631fb023c0f31c284a532d205590b393d72009c14847f5b1",
+                "sha256:826b9f5fbb7f908a13aa1efd4b7321e36992f5868d5d8311c7b40cf9b11ca0e7",
+                "sha256:a7695a378c2ce402405ea37b12c7a338a8755e081869bd6b95858893ceb617ae",
+                "sha256:a84c31e8409b420c3ca57fd30c7589378d6fdc8d155d866a7f8e6e80dec6fd06",
+                "sha256:adadeeae5500de0da2b9e8dd478520d0a9945b577b2198f2462555e68f58e7ef",
+                "sha256:b283a76a83fe463c9587a2c88003f800e08c3929dfbeba833b78260f9c209785",
+                "sha256:c19a7389ab3cd712058a8c3c9ffd8d27a57f3d84b9c91a931f542682bb3d269d",
+                "sha256:c3bb4bd2aca82fb498247deeac12265921fe231502a6bc6edea3ee7fe6c40a7a",
+                "sha256:c5ea60ece0c0c1c849025bfc541b60a6751b491b6f11dd9ef37ab5b8c9041921",
+                "sha256:db61a640ca20f237317d27bc658c1fc54c7581ff7f6502d112922dc285bdabee"
             ],
-            "version": "==1.2.1"
+            "version": "==1.3.0"
         },
         "six": {
             "hashes": [
@@ -428,9 +421,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:8027fa183f5be466030617a497b2d64e0e16c8d615e5a34bdf9fab6f66bf4723"
+                "sha256:c30925d60af95443458ebd7525daf791f55762b106049ae71e18f8dd58084c2f"
             ],
-            "version": "==1.2.18"
+            "version": "==1.3.5"
         },
         "statsmodels": {
             "hashes": [
@@ -461,30 +454,31 @@
         },
         "tables": {
             "hashes": [
-                "sha256:07bb9e96b762874e239ad8cec2cab2c4129abf576fffcdd4e961482dc7d5a0a6",
-                "sha256:09eed21e12a1286ac2e8c5e67a75d9c7a7f262883535a31ac0b985540135d8d6",
-                "sha256:0bd7e5d7ff90df3751bfb2494d41858b96118965edd8cc03758bbc638e2e2f2c",
-                "sha256:2379bc98dd8caa6f5824daae4b3b1e53008af32c7b684c67deaeebc1a89a929e",
-                "sha256:2cd49a98e750fe78b7a2b8e0efd69be608c8358f664f3705c98cc6f04da18a53",
-                "sha256:415731ae46dfdef7fbe305399a700a54b06a82c4331ba20cc64004fb40e79069",
-                "sha256:44289caf89efac435f49fa4bd298eb48969c026dec25d3a76e7955f1281d1bdf",
-                "sha256:714f7162ffa4d470da8c9a067935520e5925384445bdb23989351b48d236345c",
-                "sha256:82d98123cf67c012d6c7cb69c6733b51eb10d17fc40547bbb71ffedae8da4f90",
-                "sha256:b625fc71f082011806a60d3b7370f75e34b141dab549ed65957aed54d1f12f63",
-                "sha256:bc1621bd84769ff3f84cfd1481f93ed0c537db4b3355576270bdbb79bb390b1f",
-                "sha256:bdc5c073712af2a43babd139c4855fc99496bb2c3f3f5d1b4770a985e6f9ce29",
-                "sha256:bed4f423dd33600907f1c3b88f994920f2b879b12bf83d4372f861ef4085e085",
-                "sha256:c3ac22e3391f67a381d9a3018fd7e0a1ccfcc88b5f61b0d051fe5eba8196388f",
-                "sha256:d263f4380a5dad862efac774428bacb04c2339c4f165f2efdd228867abaffcf6",
-                "sha256:da98c8abfeefefad40110b994d5d06ac28d89b00d085530d377376b201566ebf",
-                "sha256:e2e4e40d010a6aa0464e5e281d4aa15f64acd99fd881c0e1e4c1c567b7167dba",
-                "sha256:e3bd7084dbf80ef347ad5d33645584e0fe7f8353cf2c33d8922a4c00034fa015",
-                "sha256:e8f9b20b9623c900e7007b89a9d3e315280b666ac70b38b0c191345f7d4d8585",
-                "sha256:f786d310cf954eaf52340680dfbc5c1190afc276093f5c454fab605a11488306",
-                "sha256:f97c8b5ebec23894fc56af25c6e73bc86b463cbccb1f9b9887def24cd7811e2c",
-                "sha256:fd3e774ff048de838df39b018c171bff3ecd9f34a908395a475ba07ac270a34a"
+                "sha256:018cc65a36578e3a8d05465a97d596e3a13707ed6970bacaf3ab0b91759f0e4d",
+                "sha256:069cca4fc81fd464fe4654d13f4193cfb81a22de524abeaf7295f6400b30f381",
+                "sha256:23065545e018d65dc209156805aa3e933c9872de6d63c623048524f54b16147f",
+                "sha256:459596b4f73c12511e97c985ebe1f36a58fb13543a9cc22f4a0a326497221f1e",
+                "sha256:4bd24a3dbf9272a7f886b1443f916ad25205fc8a1237a280d94ccd1bfa886fe1",
+                "sha256:5972fd758b2e0f535e7b6ec07532dcd41a0a98421205a9dad54eca053b8a9535",
+                "sha256:6100623e7fbc820ee5d1f7e82ac50a38062ab93e6e96d7a90c0fb70776d95847",
+                "sha256:63c1a1059a42be4519db6e337f692b150f50d71d57f70614ffbe0551b19cdd05",
+                "sha256:65d84305c5aa05c5c020d6afb39f07d7a01b1b7efaad1feb4c7f484df08371f2",
+                "sha256:6d6a88b7c51ec04ed8d0bead5a31ff67246a4f28fa32d1efe066f385149fc3f5",
+                "sha256:8fde91ab80e588a3fd71fe0476d7e77cd51f5bbab9163965f21f3d637bc2351f",
+                "sha256:91d76df0b4931fa110839f594e8ccdc535d1c94a46ea0cab7af8b993b951e05a",
+                "sha256:9ddd36f0b0fc7aa53d47e64d068578e7a857a93c6fb56ed6598285990c33eecf",
+                "sha256:a2d3da09e5b0cb7e3a6cd3cb8c37353ea5c14025d8ae2a832cce405f9c2e987e",
+                "sha256:b220e32262bab320aa41d33125a7851ff898be97c0de30b456247508e2cc33c2",
+                "sha256:b82a793ae1918da828d5339958e994c21d46cae504847affcd40b8ec7c9543e0",
+                "sha256:bc648f3d2384670f53f6bf11eb843761480605a27ade4ec655ea11aca5dd9db0",
+                "sha256:bf42234f35d57b4c3c8014755dd95f32eec95e62438a88eeaaa85b9bf6b617e5",
+                "sha256:cb60f23c3d9153fca46c73fa84c399f50fdd7521ecf7fa3fde166eacf910f122",
+                "sha256:d62b8348b3c6a417051fa342e312c336026f57e26b2447647deb48919f2a8c54",
+                "sha256:dd3e8682eb0db2858bd5aff8c62ac0de0ff15c0dd24328a9d85a5985d4224e7c",
+                "sha256:ddb08ef4ecae14769029ab793778c805911d1a1fdcdce37cf5358f4573833e55",
+                "sha256:e8698042f63530b1f1f1b2aa1deacdeac85fb01d35393a24aa64675aa5809f4e"
             ],
-            "version": "==3.4.4"
+            "version": "==3.5.2"
         },
         "toolz": {
             "hashes": [
@@ -494,23 +488,23 @@
         },
         "trading-calendars": {
             "hashes": [
-                "sha256:b8461311d2672ddbff542b00bea6550ab706a42c7bde1bb8429b6f6ca54436f3"
+                "sha256:5e355770ab81571b7b0207e9dc63954cecaed9068759ad885c213444fe9ae2a9"
             ],
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
+                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
             ],
-            "version": "==1.24.1"
+            "version": "==1.24.3"
         },
         "websocket-client": {
             "hashes": [
-                "sha256:47a3ddf3ee7ecd4e2f81610bcdc7f44d5dd03b602b911d4ce991cd82310d3f3b",
-                "sha256:f6029deea21218f2c771848935aa26c15699c831770f4fa66958bdaabff80ca0"
+                "sha256:1151d5fb3a62dc129164292e1227655e4bbc5dd5340a5165dfae61128ec50aa9",
+                "sha256:1fd5520878b68b84b5748bb30e592b10d0a91529d5383f74f4964e72b297fd3a"
             ],
-            "version": "==0.55.0"
+            "version": "==0.56.0"
         },
         "websockets": {
             "hashes": [
@@ -540,9 +534,9 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
+                "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
             ],
-            "version": "==1.11.1"
+            "version": "==1.11.2"
         },
         "zipline": {
             "hashes": [
@@ -562,46 +556,46 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "coverage": {
             "hashes": [
-                "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
-                "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
-                "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
-                "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
-                "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
-                "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
-                "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
-                "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
-                "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
-                "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
-                "sha256:510986f9a280cd05189b42eee2b69fecdf5bf9651d4cd315ea21d24a964a3c36",
-                "sha256:5535dda5739257effef56e49a1c51c71f1d37a6e5607bb25a5eee507c59580d1",
-                "sha256:5a7524042014642b39b1fcae85fb37556c200e64ec90824ae9ecf7b667ccfc14",
-                "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
-                "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
-                "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
-                "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
-                "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
-                "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
-                "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
-                "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
-                "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
-                "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
-                "sha256:b3b0c8f660fae65eac74fbf003f3103769b90012ae7a460863010539bb7a80da",
-                "sha256:bab8e6d510d2ea0f1d14f12642e3f35cefa47a9b2e4c7cea1852b52bc9c49647",
-                "sha256:c45297bbdbc8bb79b02cf41417d63352b70bcb76f1bbb1ee7d47b3e89e42f95d",
-                "sha256:d19bca47c8a01b92640c614a9147b081a1974f69168ecd494687c827109e8f42",
-                "sha256:d64b4340a0c488a9e79b66ec9f9d77d02b99b772c8b8afd46c1294c1d39ca478",
-                "sha256:da969da069a82bbb5300b59161d8d7c8d423bc4ccd3b410a9b4d8932aeefc14b",
-                "sha256:ed02c7539705696ecb7dc9d476d861f3904a8d2b7e894bd418994920935d36bb",
-                "sha256:ee5b8abc35b549012e03a7b1e86c09491457dba6c94112a2482b18589cc2bdb9"
+                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
+                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
+                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
+                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
+                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
+                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
+                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
+                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
+                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
+                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
+                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
+                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
+                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
+                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
+                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
+                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
+                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
+                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
+                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
+                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
+                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
+                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
+                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
+                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
+                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
+                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
+                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
+                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
+                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
+                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
+                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
             ],
-            "version": "==4.5.2"
+            "version": "==4.5.3"
         },
         "entrypoints": {
             "hashes": [
@@ -612,11 +606,18 @@
         },
         "flake8": {
             "hashes": [
-                "sha256:6d8c66a65635d46d54de59b027a1dda40abbe2275b3164b634835ac9c13fd048",
-                "sha256:6eab21c6e34df2c05416faa40d0c59963008fff29b6f0ccfe8fa28152ab3e383"
+                "sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661",
+                "sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8"
             ],
             "index": "pypi",
-            "version": "==3.7.6"
+            "version": "==3.7.7"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
+                "sha256:cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
+            ],
+            "version": "==0.18"
         },
         "mccabe": {
             "hashes": [
@@ -627,18 +628,25 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
-                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
+                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
+                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
             ],
             "markers": "python_version > '2.7'",
-            "version": "==6.0.0"
+            "version": "==7.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+            ],
+            "version": "==19.0"
         },
         "pluggy": {
             "hashes": [
-                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
-                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
-            "version": "==0.9.0"
+            "version": "==0.12.0"
         },
         "py": {
             "hashes": [
@@ -656,26 +664,33 @@
         },
         "pyflakes": {
             "hashes": [
-                "sha256:5e8c00e30c464c99e0b501dc160b13a14af7f27d4dffb529c556e30a159e231d",
-                "sha256:f277f9ca3e55de669fba45b7393a1449009cff5a37d1af10ebb76c52765269cd"
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
             ],
-            "version": "==2.1.0"
+            "version": "==2.1.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+            ],
+            "version": "==2.4.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:067a1d4bf827ffdd56ad21bd46674703fce77c5957f6c1eef731f6146bfcef1c",
-                "sha256:9687049d53695ad45cf5fdc7bbd51f0c49f1ea3ecfc4b7f3fde7501b541f17f4"
+                "sha256:4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45",
+                "sha256:926855726d8ae8371803f7b2e6ec0a69953d9c6311fa7c3b6c1b929ff92d27da"
             ],
             "index": "pypi",
-            "version": "==4.3.0"
+            "version": "==4.6.3"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33",
-                "sha256:230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f"
+                "sha256:2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6",
+                "sha256:e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"
             ],
             "index": "pypi",
-            "version": "==2.6.1"
+            "version": "==2.7.1"
         },
         "six": {
             "hashes": [
@@ -683,6 +698,20 @@
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
+            ],
+            "version": "==0.5.1"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "20e3015f4f3fcead9b55726d4691e57d8010d55725abbfdb71d9737cc4097dec"
+            "sha256": "64cbde4f00effee0bdb8cc9646ad146902e9c4c131d808761ed7a3ce53c2c7e7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,9 +18,9 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:828dcaa922155a2b7166c4f36ec45268944e4055c86499bd14319b4c8c0094b7"
+                "sha256:cdb7d98bd5cbf65acd38d70b1c05573c432e6473a82f955cdea541b5c153b0cc"
             ],
-            "version": "==1.0.10"
+            "version": "==1.0.11"
         },
         "alpaca-trade-api": {
             "hashes": [
@@ -137,11 +137,11 @@
         },
         "iexfinance": {
             "hashes": [
-                "sha256:a086bd46f14340373328824cb2cf9a75f3db101b0869e6a99d9b110e38272d61",
-                "sha256:e74c9e3ff7ebe2b94a8588b04b93573f50d3336f418e352c9437fe92818a3005"
+                "sha256:3671d56f17e8799ec3e3dad9fbff94ff141c7e1146755e1bb9208b2a23ed6fa9",
+                "sha256:7b2eb4266a84583ca50ceaff6dea1379f948112c4fa4ce97e049608a9ff65a98"
             ],
             "index": "pypi",
-            "version": "==0.4.1"
+            "version": "==0.4.2"
         },
         "intervaltree": {
             "hashes": [
@@ -427,30 +427,27 @@
         },
         "statsmodels": {
             "hashes": [
-                "sha256:0fd6af8db18b776c81c8fba54de20e9ec2f11b9310871b6b666d8805e3cf5ece",
-                "sha256:18844bbd95fcf62885d195571334762533ae16de182e1032ccc1595a98ffffb4",
-                "sha256:27e87cc6cd390fce8f44df225dadf589e1df6272f36b267ccdece2a9c4f52938",
-                "sha256:2902f5eef49fc38c112ffd8168dd76f7ae27f6cb5aa735cf55bc887b49aaec6e",
-                "sha256:31c2e26436a992e66355c0b3ef4b7c9714a0aa8375952d24f0593ac7c417b1e9",
-                "sha256:5d91ad30b8e20a45f583077ffeb4352be01955033f3dcd09bc06c30be1d29e8f",
-                "sha256:5de3d525b9a8679cd6c0f7f7c8cb8508275ab86cc3c1a140b2dc6b6390adb943",
-                "sha256:6461f93a842c649922c2c9a9bc9d9c4834110b89de8c4af196a791ab8f42ba3b",
-                "sha256:78d1b40c18d41f6c683c1c184be146264a782d409a89d8ed6c78acd1e1c11659",
-                "sha256:7c1a7cf557139f4bcbf97172268a8001156e42a7eeccca04d15c0cb7c3491ada",
-                "sha256:8532885c5778f94dae7ad83c4ac3f6916d4c8eb294f47ecefe2f0d3b967e6a16",
-                "sha256:95d35b33a301ded560662c733780ce58b37e218d122bb1b9c14e216aa9d42a2a",
-                "sha256:b48e283ba171698dca3989c0c03e6f25d3f431640383d926235d26ce48f3891c",
-                "sha256:b4b4b25c0e4228b1d33098894c3b29f4546e45afb29b333582cbaa5e16f38f3c",
-                "sha256:c06fd4af98f4c7ab61c9a79fd051ad4d7247991a691c3b4883c611029bac30a2",
-                "sha256:d2003c70c854f35a6446a465c61c994486039feb2fd47345a1e9984e95d55878",
-                "sha256:d7182803cdb09f1f17a335c0eae71d84905da9b0bc35c3d2c2379745f33096d9",
-                "sha256:d9b85bd98e90a02f2192084a85c857465e40e508629ac922242dba70731d0449",
-                "sha256:e2d9fd696e2d1523386d0f64f115352acbfaf59d5ca4c681c23ea064393a2ac4",
-                "sha256:ede078fdc9af857ed454d1e9e51831b2d577255c794d4044ecc332d40f3e3b36",
-                "sha256:f512afa7bc10b848aaacab5dfff6f61255142dd3a5581f82980c12745b0b6cd3",
-                "sha256:fbf789cc6d3fadca4350fa87e5f710ad2628e1fdff71bf8f853ecd49599ebe23"
+                "sha256:0c3dc2b69b7277bbda564306f9527bc4021aff692e3e2b8f9bf1360f0082a2ba",
+                "sha256:1770ddf720e80cb944cd1a27d4a926af4a583599eecd2c8c733742d8b9b01c66",
+                "sha256:55a374ff71cec09bfca635432abfd1ba5dff21b02c070428b6adf3d8b253c0c0",
+                "sha256:65f321640e21134fc18b312fb2f3edcfbd23ddc36831a06e2445f9f2d7c01aba",
+                "sha256:6e0d1dacf56bf505a5e04156c8b4642b53d0ca652465ce70fbdfc0ad9db76b18",
+                "sha256:6e8c03755f8f0d73ce419e17cbd38df941919bc7018c0ef2b0141bb2f6c65ff8",
+                "sha256:78166e9b64fb34b5985bc701bd8bcdc6aaf75138d0c3217f38c3cb1df96197d5",
+                "sha256:923eff6a3acd0e9caf1cefadca46b02bd84df75310af65b2ebb7de18e3dd021d",
+                "sha256:9282cf552c43ec5b68c3b20f263cc8ec10cc5f899002e341f7e288ab78ea8147",
+                "sha256:a4ac11d0e3e577ae8b8a2ad322e3be04ab6f3fa24fdadf33d383bf497f9f02d9",
+                "sha256:b5009d5f0fb33976310a106dba2602e28b79a5a1c85d749820d7c75fcd4635b7",
+                "sha256:b8fcb3f75fb95191ca8496ceebb61d34777e796191c46fd08129b6a1f17a4e8a",
+                "sha256:bbe50f3ba48a47bedc7822e8e5b4e1e063386b4aa7d0a567e5b125d9ede2a6b4",
+                "sha256:c3a0894e4af79299ff43515e6b019a64a5c355f20058094f858544e04459a562",
+                "sha256:c662f952b72eeeb82b77576a5f40bdc7e78908002decfc215cd3fa5f301e00e6",
+                "sha256:ccb9b53b74410d5728a7868b8255fa638a40635d7fed937877f76efb468ccab4",
+                "sha256:d1a346a6897f9e236308184fcb729585a1604ab27f88674babd0ffb2931d5f3e",
+                "sha256:d2ee2aab367f53eb3c5a88d241ce26db5d590a61979bb892497ba877e7240a9f",
+                "sha256:e2f04f5b3dd6a980b95dd913f84fd22b5e695ddd9a26ffc268fec8741c40a8e2"
             ],
-            "version": "==0.9.0"
+            "version": "==0.10.0"
         },
         "tables": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ APCA_API_KEY_ID
 APCA_API_SECRET_KEY
 ```
 
-### pipeline_live.data.iex.pricing.USEquityPricing
+### pipeline_live.data.alpaca.pricing.USEquityPricing
 This class provides the basic price information retrieved from
 [Alpaca Data API](https://docs.alpaca.markets/api-documentation/api-v2/market-data/bars/).
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ If you are looking to use this library for your Quantopian algorithm,
 check out the [migration document](./migration.md).
 
 ## Data Sources
-This library predominantly relies on the [IEX public data API](https://iextrading.com/developer/docs/) for daily
-prices and fundamentals, but plans to connect to other data sources in
-the future. Currently supported data sources include the following.
+This library predominantly relies on the [Alpaca Data API](https://docs.alpaca.markets/api-documentation/api-v2/market-data/) for daily
+price data. For users with funded Alpaca brokerage accounts, several [Polygon](https://polygon.io/) fundamental
+data endpoints are supported. [IEX Cloud](https://iexcloud.io/docs/api/) data is also supported, though if too much
+data is requested, it stops being free. (See the note in the IEX section below.)
 
-- [Alpaca/Polygon](https://docs.alpaca.markets/)
 
 ## Install
 
@@ -75,8 +75,47 @@ and returns a DataFrame with the data for the current date (US/Eastern time).
 Its constructor accepts `list_symbol` function that is supposed to return the full set of
 symbols as a string list, which is used as the maximum universe inside the engine.
 
+## Alpaca Data API
+The [Alpaca Data API](https://docs.alpaca.markets/api-documentation/api-v2/market-data/) is currently the least-limited source of pricing data
+supported by pipeline-live. In order to use the Alpaca Data API, you'll need to
+register for an Alpaca account [here](https://app.alpaca.markets/signup) and generate API key information with
+the dashboard. Once you have your keys generated, you need to store them in
+the following environment variables:
+
+```
+APCA_API_BASE_URL
+APCA_API_KEY_ID
+APCA_API_SECRET_KEY
+```
+
+### pipeline_live.data.iex.pricing.USEquityPricing
+This class provides the basic price information retrieved from
+[Alpaca Data API](https://docs.alpaca.markets/api-documentation/api-v2/market-data/bars/).
+
+## Polygon Data Source API
+You will need to set an [Alpaca](https://alpaca.markets/) API key as `APCA_API_KEY_ID` to use this API.
+
+### pipeline_live.data.polygon.fundamentals.PolygonCompany
+This class provides the DataSet interface using
+[Polygon Symbol Details API](https://polygon.io/docs/#!/Meta-Data/get_v1_meta_symbols_symbol_company)
+
+### pipeline_live.data.polygon.filters.IsPrimaryShareEmulation
+Experimental. This class filteres symbols by the following
+rule to return something close to
+[IsPrimaryShare()](https://www.quantopian.com/help#quantopian_pipeline_filters_fundamentals_IsPrimaryShare) in Quantopian.
+
+- must be a US company
+- must have a valid financial data
+
 ## IEX Data Source API
-You don't have to configure anything to use these API
+To use IEX-source data, you need to sign up for an IEX Cloud account and save
+your IEX token as an environment variable called `IEX_TOKEN`.
+
+IMPORTANT NOTE: IEX data is now limited for free accounts. In order to
+avoid using more messages than you are allotted each month, please
+be sure that you are not using IEX-sourced factors too frequently
+or on too many securities. For more information about how many messages
+each method will cost, please refer to [this part](https://iexcloud.io/docs/api/#data-weighting) of the IEX Cloud documentation.
 
 ### pipeline_live.data.iex.pricing.USEquityPricing
 This class provides the basic price information retrieved from
@@ -102,18 +141,3 @@ A shortcut for `IEXCompany.sector.latest`
 
 ### pipeline_live.data.iex.classifiers.Industry()
 A shortcut for `IEXCompany.industry.latest`
-
-## Alpaca/Polygon Data Source API
-You will need to set [Alpaca](https://alpaca.markets/) API key to use these API.
-
-### pipeline_live.data.polygon.fundamentals.PolygonCompany
-This class provides the DataSet interface using
-[Polygon Symbol Details API](https://polygon.io/docs/#!/Meta-Data/get_v1_meta_symbols_symbol_company)
-
-### pipeline_live.data.polygon.filters.IsPrimaryShareEmulation
-Experimental. This class filteres symbols by the following
-rule to return something close to
-[IsPrimaryShare()](https://www.quantopian.com/help#quantopian_pipeline_filters_fundamentals_IsPrimaryShare) in Quantopian.
-
-- must be a US company
-- must have a valid financial data

--- a/migration.md
+++ b/migration.md
@@ -12,20 +12,22 @@ pylivetrader can run the pipeline object from this package.
 ## USEquityPricing
 The most important class to think about first is the USEquityPricing class
 and it is well covered by
-`pipeline_live.data.iex.pricing.USEquityPricing` class.
+`pipeline_live.data.alpaca.pricing.USEquityPricing` class.
 This class gets the market-wide daily price data (OHLCV) up to the
-previous day from [IEX chart API](https://iextrading.com/developer/docs/#chart).
-Depending on the requested window length from its upstream pipeline, it
-fetches different size of the data range (e.g. 3m, 1y). Again, the volume of
-this data is market-wide size, so it's safe to use this with factors such
-as AverageDollarVolume.
+previous day from [Alpaca data API](https://docs.alpaca.markets/api-documentation/api-v2/market-data/bars/).
 
 ## Factors
 In order to use many of the builtin factors with this price data loader,
-you need to use `pipeline_live.data.iex.factors` package which has
-all the builtin factor classes ported from zipline.  
+you need to use `pipeline_live.data.alpaca.factors` package which has
+all the builtin factor classes ported from zipline. Use of the Alpaca data API
+requires an Alpaca account, which you can sign up for [here](https://app.alpaca.markets/signup).
 
-For example, if you have these lines,
+Once you have an Alpaca account, you will need to store your account info
+from their dashboard as environment variables. You can find information about
+how to do so on [this documentation page](https://docs.alpaca.markets/api-documentation/how-to/).
+
+To use the Alpaca factors, import them from `pipeline_live.data.alpaca.factors`.
+For example, if you have these lines on Quantopian,
 
 ```py
 from quantopian.pipeline.factors import (
@@ -37,10 +39,10 @@ from quantopian.pipeline.data.builtin import USEquityPricing
 you can rewrite it to something like this.
 
 ```py
-from pipeline_live.data.iex.factors import (
+from pipeline_live.data.alpaca.factors import (
     AverageDollarVolume, SimpleMovingAverage,
 )
-from pipeline_live.data.iex.pricing import USEquityPricing
+from pipeline_live.data.alpaca.pricing import USEquityPricing
 ```
 
 Of course, the builtin factor classes in the original zipline are mostly
@@ -49,7 +51,7 @@ ones, they also work with this `USEquityPricing`.
 
 ```py
 from zipline.pipeline.factors import AverageDollarVolume
-from pipeline_live.data.iex.pricing import USEquityPricing
+from pipeline_live.data.alpaca.pricing import USEquityPricing
 
 dollar_volume = AverageDollarVolume(
     inputs=[USEquityPricing.close, USEquityPricing.volume],
@@ -57,18 +59,26 @@ dollar_volume = AverageDollarVolume(
 )
 ```
 
-The only difference in the factor classes in `pipeline_live.data.iex.factors`
-is that some of the classes have IEX's USEquityPricing as the default
+The only difference in the factor classes in `pipeline_live.data.alpaca.factors`
+is that some of the classes have Alpaca's USEquityPricing as the default
 inputs, so you don't need to explicitly specify it.
 
 ## Fundamentals
 The Quantopian platform allows you to retrieve various proprietary data
 sources through pipeline, including Morningstar fundamentals. While the
 intention of this pipline-live library is to add more such proprietary
-data sources, the free alternative at the moment is IEX. There are two
+data sources, the alternative at the moment is IEX. There are two
 main dataset classes are builtin in this library, `IEXCompany` and
 `IEXKeyStats`. Those both belong to the `pipeline_live.data.iex.fundamentals`
 package.
+
+Please note that, in order to use the IEX API data, you will need to sign up
+for an IEX Cloud account [here](https://iexcloud.io/cloud-login#/register/) and set your IEX Cloud token in the
+`IEX_TOKEN` environment variable. IEX limits your API messages per month. In
+order to avoid running over your message quota, please make sure that you
+filter your stock universe as much as possible before using IEX API data.
+If you wish to use IEX data to frequently filter a larger set of symbols, you
+may need to upgrade your IEX Cloud account.
 
 ### IEXCompany
 This dataset class maps the basic stock information from the

--- a/pipeline_live/data/alpaca/factors.py
+++ b/pipeline_live/data/alpaca/factors.py
@@ -1,0 +1,35 @@
+'''
+Duplicate builtin factor classes in zipline with IEX's USEquityPricing
+'''
+
+from zipline.pipeline.data import USEquityPricing as z_pricing
+from zipline.pipeline import factors as z_factors
+
+from .pricing import USEquityPricing as alpaca_pricing
+
+
+def _replace_inputs(inputs):
+    map = {
+        z_pricing.open: alpaca_pricing.open,
+        z_pricing.high: alpaca_pricing.high,
+        z_pricing.low: alpaca_pricing.low,
+        z_pricing.close: alpaca_pricing.close,
+        z_pricing.volume: alpaca_pricing.volume,
+    }
+
+    if type(inputs) not in (list, tuple, set):
+        return inputs
+    return tuple([
+        map.get(inp, inp) for inp in inputs
+    ])
+
+
+for name in dir(z_factors):
+    factor = getattr(z_factors, name)
+    if factor != z_factors.Factor and hasattr(
+            factor, 'inputs') and issubclass(
+            factor, z_factors.Factor):
+        new_factor = type(factor.__name__, (factor,), {
+            'inputs': _replace_inputs(factor.inputs)
+        })
+        locals()[factor.__name__] = new_factor

--- a/pipeline_live/data/alpaca/pricing.py
+++ b/pipeline_live/data/alpaca/pricing.py
@@ -1,0 +1,23 @@
+from zipline.pipeline.data.dataset import Column, DataSet
+from zipline.utils.numpy_utils import float64_dtype
+
+from .pricing_loader import USEquityPricingLoader
+
+
+# In order to use it as a cache key, we have to make it singleton
+_loader = USEquityPricingLoader()
+
+
+class USEquityPricing(DataSet):
+    """
+    Dataset representing daily trading prices and volumes.
+    """
+    open = Column(float64_dtype)
+    high = Column(float64_dtype)
+    low = Column(float64_dtype)
+    close = Column(float64_dtype)
+    volume = Column(float64_dtype)
+
+    @staticmethod
+    def get_loader():
+        return _loader

--- a/pipeline_live/data/alpaca/pricing_loader.py
+++ b/pipeline_live/data/alpaca/pricing_loader.py
@@ -1,0 +1,115 @@
+import numpy as np
+import logbook
+import pandas as pd
+
+from zipline.lib.adjusted_array import AdjustedArray
+from zipline.pipeline.loaders.base import PipelineLoader
+from zipline.utils.calendars import get_calendar
+from zipline.errors import NoFurtherDataError
+
+from pipeline_live.data.sources import alpaca
+
+
+log = logbook.Logger(__name__)
+
+
+class USEquityPricingLoader(PipelineLoader):
+    """
+    PipelineLoader for US Equity Pricing data
+    """
+
+    def __init__(self):
+        cal = get_calendar('NYSE')
+
+        self._all_sessions = cal.all_sessions
+
+    def load_adjusted_array(self, columns, dates, symbols, mask):
+        # load_adjusted_array is called with dates on which the user's algo
+        # will be shown data, which means we need to return the data that would
+        # be known at the start of each date.  We assume that the latest data
+        # known on day N is the data from day (N - 1), so we shift all query
+        # dates back by a day.
+        start_date, end_date = _shift_dates(
+            self._all_sessions, dates[0], dates[-1], shift=1,
+        )
+
+        sessions = self._all_sessions
+        sessions = sessions[(sessions >= start_date) & (sessions <= end_date)]
+
+        timedelta = pd.Timestamp.utcnow() - start_date
+        chart_range = timedelta.days + 1
+        log.info('chart_range={}'.format(chart_range))
+        prices = alpaca.get_stockprices(chart_range)
+
+        dfs = []
+        for symbol in symbols:
+            if symbol not in prices:
+                df = pd.DataFrame(
+                    {c.name: c.missing_value for c in columns},
+                    index=sessions
+                )
+            else:
+                df = prices[symbol]
+                df = df.reindex(sessions, method='ffill')
+            dfs.append(df)
+
+        raw_arrays = {}
+        for c in columns:
+            colname = c.name
+            raw_arrays[colname] = np.stack([
+                df[colname].values for df in dfs
+            ], axis=-1)
+        out = {}
+        for c in columns:
+            c_raw = raw_arrays[c.name]
+            out[c] = AdjustedArray(
+                c_raw.astype(c.dtype),
+                {},
+                c.missing_value
+            )
+        return out
+
+
+def _shift_dates(dates, start_date, end_date, shift):
+    try:
+        start = dates.get_loc(start_date)
+    except KeyError:
+        if start_date < dates[0]:
+            raise NoFurtherDataError(
+                msg=(
+                    "Pipeline Query requested data starting on {query_start}, "
+                    "but first known date is {calendar_start}"
+                ).format(
+                    query_start=str(start_date),
+                    calendar_start=str(dates[0]),
+                )
+            )
+        else:
+            raise ValueError("Query start %s not in calendar" % start_date)
+
+    # Make sure that shifting doesn't push us out of the calendar.
+    if start < shift:
+        raise NoFurtherDataError(
+            msg=(
+                "Pipeline Query requested data from {shift}"
+                " days before {query_start}, but first known date is only "
+                "{start} days earlier."
+            ).format(shift=shift, query_start=start_date, start=start),
+        )
+
+    try:
+        end = dates.get_loc(end_date)
+    except KeyError:
+        if end_date > dates[-1]:
+            raise NoFurtherDataError(
+                msg=(
+                    "Pipeline Query requesting data up to {query_end}, "
+                    "but last known date is {calendar_end}"
+                ).format(
+                    query_end=end_date,
+                    calendar_end=dates[-1],
+                )
+            )
+        else:
+            raise ValueError("Query end %s not in calendar" % end_date)
+    return dates[start - shift], dates[end - shift]

--- a/pipeline_live/data/polygon/filters.py
+++ b/pipeline_live/data/polygon/filters.py
@@ -22,6 +22,7 @@ class IsPrimaryShareEmulation(CustomFilter):
         ], dtype=bool)
         out[:] = ary
 
+
 class StaticSymbols(CustomFilter):
     inputs = ()
     window_length = 1

--- a/pipeline_live/data/sources/alpaca.py
+++ b/pipeline_live/data/sources/alpaca.py
@@ -1,0 +1,41 @@
+import alpaca_trade_api as tradeapi
+
+from .util import (
+    daily_cache, parallelize
+)
+
+
+def list_symbols():
+    return [
+        a.symbol for a in tradeapi.REST().list_assets()
+        if a.tradable and a.status == 'active'
+    ]
+
+
+def get_stockprices(limit=365, timespan='day'):
+    all_symbols = list_symbols()
+
+    @daily_cache(filename='alpaca_chart_{}'.format(limit))
+    def get_stockprices_cached(all_symbols):
+        return _get_stockprices(all_symbols, limit, timespan)
+
+    return get_stockprices_cached(all_symbols)
+
+
+def _get_stockprices(symbols, limit=365, timespan='day'):
+    '''Get stock data (key stats and previous) from Alpaca.
+    Just deal with Alpaca's 200 stocks per request limit.
+    '''
+
+    def fetch(symbols):
+        barset = tradeapi.REST().get_barset(symbols, timespan, limit)
+        data = {}
+        for symbol in barset:
+            df = barset[symbol].df
+            # Update the index format for comparison with the trading calendar
+            df.index = df.index.tz_convert('UTC').normalize()
+            data[symbol] = df.asfreq('C')
+
+        return data
+
+    return parallelize(fetch, splitlen=199)(symbols)

--- a/pipeline_live/data/sources/iex.py
+++ b/pipeline_live/data/sources/iex.py
@@ -1,4 +1,5 @@
-import iexfinance
+from iexfinance import refdata
+from iexfinance.stocks import Stock
 import pandas as pd
 
 from .util import (
@@ -8,7 +9,7 @@ from .util import (
 
 def list_symbols():
     return [
-        symbol['symbol'] for symbol in iexfinance.refdata.get_symbols()
+        symbol['symbol'] for symbol in refdata.get_iex_symbols()
     ]
 
 
@@ -30,7 +31,7 @@ class IEXGetter(object):
         def _get(all_symbols):
             def fetch(symbols):
                 return _ensure_dict(
-                    getattr(iexfinance.stocks.Stock(symbols), method_name)(),
+                    getattr(Stock(symbols), method_name)(),
                     symbols
                 )
 
@@ -67,7 +68,7 @@ def _get_stockprices(symbols, chart_range='1y'):
 
     def fetch(symbols):
         charts = _ensure_dict(
-            iexfinance.stocks.Stock(symbols).get_chart(range=chart_range),
+            Stock(symbols).get_chart(range=chart_range),
             symbols
         )
         result = {}

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'alpaca-trade-api',
-        'iexfinance==0.4.0',
+        'iexfinance>=0.4.1',
         'zipline==1.3.0',
         'numpy==1.16.1',
     ],

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     keywords='financial,zipline,pipeline,stock,screening,api,trade',
     packages=find_packages(),
     install_requires=[
-        'alpaca-trade-api',
+        'alpaca-trade-api>=0.29',
         'iexfinance>=0.4.1',
         'zipline==1.3.0',
         'numpy==1.16.1',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from pipeline_live.data.sources import polygon as sources_polygon
 from pipeline_live.data.sources import iex as sources_iex
+from pipeline_live.data.sources import alpaca as sources_alpaca
 
 
 @pytest.fixture
@@ -13,9 +14,21 @@ def tradeapi():
 
 
 @pytest.fixture
-def iexfinance():
-    with patch.object(sources_iex, 'iexfinance') as iexfinance:
-        yield iexfinance
+def alpaca_tradeapi():
+    with patch.object(sources_alpaca, 'tradeapi') as tradeapi:
+        yield tradeapi
+
+
+@pytest.fixture
+def refdata():
+    with patch.object(sources_iex, 'refdata') as refdata:
+        yield refdata
+
+
+@pytest.fixture
+def stocks():
+    with patch.object(sources_iex, 'Stock') as stocks:
+        yield stocks
 
 
 @pytest.fixture

--- a/tests/datamock/mock_iex.py
+++ b/tests/datamock/mock_iex.py
@@ -1,7 +1,7 @@
 
 
-def get_available_symbols(iexfinance):
-    iexfinance.refdata.get_symbols.return_value = [
+def get_available_symbols(refdata):
+    refdata.get_iex_symbols.return_value = [
         {
             "symbol": "A",
             "name": "AGILENT TECHNOLOGIES INC",
@@ -21,8 +21,8 @@ def get_available_symbols(iexfinance):
     ]
 
 
-def get_key_stats(iexfinance):
-    iexfinance.stocks.Stock().get_key_stats.return_value = {
+def get_key_stats(stocks):
+    stocks().get_key_stats.return_value = {
         'A': {
             'companyName': 'Agilent Technologies Inc.',
             'marketcap': 20626540000,
@@ -127,8 +127,8 @@ def get_key_stats(iexfinance):
             'day30ChangePercent': -0.12963346448540067}}
 
 
-def get_financials(iexfinance):
-    iexfinance.stocks.Stock().get_financials.return_value = {'AA': [
+def get_financials(stocks):
+    stocks().get_financials.return_value = {'AA': [
         {'reportDate': '2018-06-30',
          'grossProfit': 947000000,
          'costOfRevenue': 2632000000,
@@ -211,8 +211,8 @@ def get_financials(iexfinance):
             'operatingGainsLosses': 16000000}]}
 
 
-def get_chart(iexfinance):
-    iexfinance.stocks.Stock().get_chart.return_value = {
+def get_chart(stocks):
+    stocks().get_chart.return_value = {
         'AA': [{
             'date': '2018-08-21',
             'open': 41.88,

--- a/tests/datamock/mock_tradeapi.py
+++ b/tests/datamock/mock_tradeapi.py
@@ -1,4 +1,4 @@
-from alpaca_trade_api.entity import Asset
+from alpaca_trade_api.entity import Asset, BarSet
 
 
 def list_assets(tradeapi):
@@ -16,6 +16,16 @@ def list_assets(tradeapi):
                'symbol': 'A',
                'tradable': True}),
     ]
+
+
+def get_barset(tradeapi):
+    tradeapi.REST().get_barset.return_value = BarSet({
+        "AA": [{"t": 1544129220,
+                "o": 172.26,
+                "h": 172.3,
+                "l": 172.16,
+                "c": 172.18,
+                "v": 3892}]})
 
 
 def list_financials(tradeapi):

--- a/tests/test_alpaca.py
+++ b/tests/test_alpaca.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import numpy as np
+
+from .datamock import mock_tradeapi
+
+from pipeline_live.data.alpaca.pricing import USEquityPricing
+
+def test_pricing_loader(refdata, alpaca_tradeapi, data_path):
+    mock_tradeapi.list_assets(alpaca_tradeapi)
+    mock_tradeapi.get_barset(alpaca_tradeapi)
+
+    loader = USEquityPricing.get_loader()
+    columns = [USEquityPricing.close]
+    dates = [pd.Timestamp('2018-08-22', tz='UTC')]
+    symbols = ['AA']
+    mask = np.zeros((1, 1), dtype='bool')
+    out = loader.load_adjusted_array(columns, dates, symbols, mask)
+
+    assert out[USEquityPricing.close]._data.shape == (1, 1)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8,13 +8,13 @@ from zipline.pipeline import Pipeline
 from .datamock import mock_iex
 
 
-def test_engine(iexfinance, data_path):
+def test_engine(refdata, stocks, data_path):
     def list_symbols():
         return ['A', 'AA']
 
-    mock_iex.get_available_symbols(iexfinance)
-    mock_iex.get_key_stats(iexfinance)
-    mock_iex.get_chart(iexfinance)
+    mock_iex.get_available_symbols(refdata)
+    mock_iex.get_key_stats(stocks)
+    mock_iex.get_chart(stocks)
 
     eng = LivePipelineEngine(list_symbols)
     ADV = AverageDollarVolume(window_length=20,)

--- a/tests/test_iex.py
+++ b/tests/test_iex.py
@@ -7,10 +7,10 @@ from pipeline_live.data.iex.pricing import USEquityPricing
 from .datamock import mock_iex
 
 
-def test_IEXKeyStats(iexfinance, data_path):
+def test_IEXKeyStats(refdata, stocks, data_path):
 
-    mock_iex.get_available_symbols(iexfinance)
-    mock_iex.get_key_stats(iexfinance)
+    mock_iex.get_available_symbols(refdata)
+    mock_iex.get_key_stats(stocks)
 
     marketcap = IEXKeyStats.marketcap
     loader = marketcap.dataset.get_loader()
@@ -20,9 +20,9 @@ def test_IEXKeyStats(iexfinance, data_path):
     assert out[marketcap][0][0] != 0.0
 
 
-def test_pricing_loader(iexfinance, data_path):
-    mock_iex.get_available_symbols(iexfinance)
-    mock_iex.get_chart(iexfinance)
+def test_pricing_loader(refdata, stocks, data_path):
+    mock_iex.get_available_symbols(refdata)
+    mock_iex.get_chart(stocks)
 
     loader = USEquityPricing.get_loader()
     columns = [USEquityPricing.close]

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -1,6 +1,8 @@
 import pandas as pd
 from pipeline_live.data.polygon.fundamentals import PolygonCompany
-from pipeline_live.data.polygon.filters import IsPrimaryShareEmulation, StaticSymbols
+from pipeline_live.data.polygon.filters import (
+    IsPrimaryShareEmulation, StaticSymbols
+)
 
 from .datamock import mock_tradeapi
 
@@ -29,8 +31,9 @@ def test_IsPrimaryShareEmulation(tradeapi, data_path):
     emu.compute(today, symbols, out)
     assert not out[0]
 
+
 def test_StaticSymbols(tradeapi, data_path):
-    symbols=('A', 'BB')
+    symbols = ('A', 'BB')
     emu = StaticSymbols(symbols=symbols)
 
     today = object()

--- a/tests/test_polygon.py
+++ b/tests/test_polygon.py
@@ -30,10 +30,11 @@ def test_IsPrimaryShareEmulation(tradeapi, data_path):
     assert not out[0]
 
 def test_StaticSymbols(tradeapi, data_path):
-    emu = StaticSymbols(symbols=('A', 'BB'))
+    symbols=('A', 'BB')
+    emu = StaticSymbols(symbols=symbols)
 
     today = object()
     assets = ['A', 'AA', 'BB']
     out = [None, None, None]
-    emu.compute(today, assets, out)
+    emu.compute(today, assets, out, symbols)
     assert not out[1]

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,6 +1,14 @@
-from pipeline_live.data.sources import iex, polygon
+from pipeline_live.data.sources import alpaca, iex, polygon
 
 from .datamock import mock_iex, mock_tradeapi
+
+
+def test_alpaca(alpaca_tradeapi, data_path):
+    mock_tradeapi.list_assets(alpaca_tradeapi)
+    mock_tradeapi.get_barset(alpaca_tradeapi)
+
+    data = alpaca.get_stockprices(2)
+    assert data['AA'].iloc[0].close == 172.18
 
 
 def test_polygon(tradeapi, data_path):
@@ -17,9 +25,9 @@ def test_polygon(tradeapi, data_path):
     assert data['AA']['name'] == 'Alcoa Corp'
 
 
-def test_iex(iexfinance, data_path):
-    mock_iex.get_available_symbols(iexfinance)
-    mock_iex.get_key_stats(iexfinance)
+def test_iex(refdata, stocks, data_path):
+    mock_iex.get_available_symbols(refdata)
+    mock_iex.get_key_stats(stocks)
 
     kstats = iex.key_stats()
 
@@ -30,7 +38,7 @@ def test_iex(iexfinance, data_path):
     kstats = iex.key_stats()
     assert kstats['AA']['returnOnCapital'] is None
 
-    mock_iex.get_financials(iexfinance)
+    mock_iex.get_financials(stocks)
 
     financials = iex.financials()
     assert len(financials) == 1
@@ -39,7 +47,7 @@ def test_iex(iexfinance, data_path):
     ed = iex._ensure_dict(1, ['AA'])
     assert ed['AA'] == 1
 
-    mock_iex.get_chart(iexfinance)
+    mock_iex.get_chart(stocks)
 
     data = iex.get_stockprices()
     assert len(data) == 1


### PR DESCRIPTION
Much of the data available through IEX's public API has been moved to IEX Cloud. As such, its chart method is not as viable of a free data source for pipeline-live due to the high message volume it tends to generate. This PR updates the existing code which utilizes IEX to use the newer version of their API. It also adds the data available through Alpaca's API as a source as an alternative.