### PR TITLE
fixing iex load_symbols

### DIFF
--- a/pipeline_live/data/sources/iex.py
+++ b/pipeline_live/data/sources/iex.py
@@ -9,7 +9,7 @@ from .util import (
 
 def list_symbols():
     return [
-        symbol['symbol'] for symbol in refdata.get_iex_symbols()
+        symbol['symbol'] for symbol in refdata.get_symbols()
     ]
 
 


### PR DESCRIPTION
get_iex_symbols returns symbols that are not eligible for api access. The get_symbols method should play nice with all IEX api endpoints.

https://addisonlynch.github.io/iexfinance/stable/refdata.html#id3

The change fixes this ticket
https://github.com/alpacahq/pipeline-live/issues/13