### PR TITLE
Reuse sessions for Alpaca API calls

### DIFF
--- a/pipeline_live/data/sources/alpaca.py
+++ b/pipeline_live/data/sources/alpaca.py
@@ -6,11 +6,11 @@ from .util import (
 
 
 def list_symbols():
-    with tradeapi.REST() as api:
-        return [
-            a.symbol for a in api.list_assets()
-            if a.tradable and a.status == 'active'
-        ]
+    api = tradeapi.REST()
+    return [
+        a.symbol for a in api.list_assets()
+        if a.tradable and a.status == 'active'
+    ]
 
 
 def get_stockprices(limit=365, timespan='day'):
@@ -41,5 +41,4 @@ def _get_stockprices(symbols, limit=365, timespan='day'):
 
         return data
 
-    with api:
-        return parallelize(fetch, splitlen=199)(symbols)
+    return parallelize(fetch, splitlen=199)(symbols)

--- a/pipeline_live/data/sources/alpaca.py
+++ b/pipeline_live/data/sources/alpaca.py
@@ -6,10 +6,11 @@ from .util import (
 
 
 def list_symbols():
-    return [
-        a.symbol for a in tradeapi.REST().list_assets()
-        if a.tradable and a.status == 'active'
-    ]
+    with tradeapi.REST() as api:
+        return [
+            a.symbol for a in api.list_assets()
+            if a.tradable and a.status == 'active'
+        ]
 
 
 def get_stockprices(limit=365, timespan='day'):
@@ -27,8 +28,10 @@ def _get_stockprices(symbols, limit=365, timespan='day'):
     Just deal with Alpaca's 200 stocks per request limit.
     '''
 
+    api = tradeapi.REST()
+
     def fetch(symbols):
-        barset = tradeapi.REST().get_barset(symbols, timespan, limit)
+        barset = api.get_barset(symbols, timespan, limit)
         data = {}
         for symbol in barset:
             df = barset[symbol].df
@@ -38,4 +41,5 @@ def _get_stockprices(symbols, limit=365, timespan='day'):
 
         return data
 
-    return parallelize(fetch, splitlen=199)(symbols)
+    with api:
+        return parallelize(fetch, splitlen=199)(symbols)


### PR DESCRIPTION
I haven't fully tested this but I think this will fix these warning and make better use of http sessions:

```
pipeline_live/data/sources/alpaca.py:31: ResourceWarning: unclosed <ssl.SSLSocket fd=123, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('1.2.3.4', 1234), raddr=('34.86.145.125', 443)>
  barset = tradeapi.REST().get_barset(symbols, timespan, limit)
```