### PR TITLE
Pull only US equities, not crypto

### DIFF
--- a/pipeline_live/data/sources/alpaca.py
+++ b/pipeline_live/data/sources/alpaca.py
@@ -8,7 +8,7 @@ from .util import (
 
 def list_symbols():
     api = REST()
-    return [a.symbol for a in api.list_assets(status="active") if a.tradable]
+    return [a.symbol for a in api.list_assets(status="active", asset_class ="us_equity") if a.tradable]
 
 def get_stockprices(limit=365, timespan='day'):
     all_symbols = list_symbols()


### PR DESCRIPTION
I changed the alpaca.py file to pull the only the us_equity asset class instead of us_equity + crypto. This solves an error during runtime in which crypto pairs are interpreted as equities. I'm not sure if this is the best plan of action, but it does allow the package to run again. 

If there are better options, let me know. 

Thanks,
Vincent 